### PR TITLE
Ubuntu22.04, JAVA_HOME, Clean Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,32 +1,25 @@
-# Fetch ubuntu 18.04 LTS docker image
-FROM ubuntu:18.04
+# Fetch ubuntu 22.04 LTS docker image
+FROM ubuntu:22.04
 
-ENV DEBIAN_FRONTEND=noninteractive 
-#[DEPRECATED] Make a copy of ubuntu apt repository before modifying it. 
-#RUN mv /etc/apt/sources.list /sources.list
-#[DEPRECATED] Now change the default ubuntu apt repositry, which is VERY slow, to another mirror that is much faster. It assumes the host already has created a sources.list.
-#COPY sources.list /etc/apt/sources.list
-COPY WordCount.java /etc/apt/WordCount.java
-COPY TopWords.java /etc/apt/TopWords.java
-
-#uncomment this line to find the fastest ubuntu repository at the time. Probably overkill, so disabling for now
-#Note that this functionality is untested and might need debugging a bit.
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update apt, and install Java + curl + wget on your ubuntu image.
-RUN \
-  apt-get update && \
-  apt-get install -y curl vim wget expect git zip unzip && \
-  apt-get install -y openjdk-8-jdk 
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    vim \
+    wget \
+    expect \
+    git \
+    zip \
+    unzip \
+    openjdk-8-jdk \
+    python3 \
+    && apt-get clean
 
-RUN \
-  apt-get install -y python3 
-  # && \
-  #apt-get install -y python3-pip
-
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-2.9.2/hadoop-2.9.2.tar.gz" | tar -xz -C /usr/local/
-RUN cd /usr/local && ln -s ./hadoop-2.9.2 hadoop
-
+RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-2.9.2/hadoop-2.9.2.tar.gz" | tar -xz -C /usr/local/ \
+    && ln -s /usr/local/hadoop-2.9.2 /usr/local/hadoop \
+    && chmod a+rwx -R /usr/local/hadoop/
 
 ENV HADOOP_PREFIX /usr/local/hadoop
 ENV HADOOP_COMMON_HOME /usr/local/hadoop
@@ -35,28 +28,43 @@ ENV HADOOP_MAPRED_HOME /usr/local/hadoop
 ENV HADOOP_YARN_HOME /usr/local/hadoop
 ENV HADOOP_CONF_DIR /usr/local/hadoop/etc/hadoop
 ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
-ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar
+# ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar
 ENV PATH="/usr/local/hadoop/bin:${PATH}"
 
-RUN sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
-RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+# Test the arch and set JAVA_HOME accordingly:
+# ARM64/aarch64: /usr/lib/jvm/java-8-openjdk-arm64
+# X84_64: /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64; else export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64; fi \
+    && export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar \
+    && sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && sed -i "/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && echo "export JAVA_HOME=$JAVA_HOME" >> $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && echo "export JAVA_HOME=$JAVA_HOME" >> /root/.bashrc
+
+# RUN sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+# RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 
 
-RUN chmod a+rwx -R /usr/local/hadoop/
 #COPY autosu /usr/local/bin
 #RUN chmod 777 /usr/local/bin/autosu
 #RUN adduser hadoopuser --disabled-password --gecos ""
 #RUN echo 'hadoopuser:hadooppass' | chpasswd
 
 # Download and setup Apache Spark
-RUN curl -s "https://archive.apache.org/dist/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz" | tar -xz -C /usr/local/
-RUN ln -s /usr/local/spark-2.2.1-bin-hadoop2.7 /usr/local/spark
-
-ENV SPARK_HOME /usr/local/spark
+RUN curl -s "https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz" | tar -xz  -C /usr/local/ \
+    && ln -s /usr/local/spark-3.3.2-bin-hadoop2 /usr/local/spark \
+    && chmod a+rwx -R /usr/local/spark/
 ENV PATH="/usr/local/spark/bin:${PATH}"
-RUN chmod a+rwx -R /usr/local/spark/
+ENV SPARK_HOME /usr/local/spark
 
 # Make vim nice
 RUN echo "set background=dark" >> ~/.vimrc
-
 ENV PYSPARK_PYTHON=python3
+
+COPY WordCount.java /etc/apt/WordCount.java
+COPY TopWords.java /etc/apt/TopWords.java
+
+# [Optional] Set working path to /cs498, and run the following command to start the container with code:
+# WORKDIR /cs498
+# docker run -it --rm --mount type=bind,source=$PATH_TO_CODE,target=/cs498/ sample_image.v1 /bin/bash

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && \
     python3 \
     && apt-get clean
 
-RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-2.9.2/hadoop-2.9.2.tar.gz" | tar -xz -C /usr/local/ \
-    && ln -s /usr/local/hadoop-2.9.2 /usr/local/hadoop \
+RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-3.3.5/hadoop-3.3.5.tar.gz" | tar -xz -C /usr/local/ \
+    && ln -s /usr/local/hadoop-3.3.5 /usr/local/hadoop \
     && chmod a+rwx -R /usr/local/hadoop/
 
 ENV HADOOP_PREFIX /usr/local/hadoop
@@ -50,13 +50,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.8
 #RUN chmod 777 /usr/local/bin/autosu
 #RUN adduser hadoopuser --disabled-password --gecos ""
 #RUN echo 'hadoopuser:hadooppass' | chpasswd
-
-# Download and setup Apache Spark
-RUN curl -s "https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz" | tar -xz  -C /usr/local/ \
-    && ln -s /usr/local/spark-3.3.2-bin-hadoop2 /usr/local/spark \
-    && chmod a+rwx -R /usr/local/spark/
-ENV PATH="/usr/local/spark/bin:${PATH}"
-ENV SPARK_HOME /usr/local/spark
 
 # Make vim nice
 RUN echo "set background=dark" >> ~/.vimrc

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     git \
     zip \
     unzip \
-    openjdk-8-jdk \
+    openjdk-17-jdk \
     python3 \
     && apt-get clean
 
@@ -35,7 +35,7 @@ ENV PATH="/usr/local/hadoop/bin:${PATH}"
 # ARM64/aarch64: /usr/lib/jvm/java-8-openjdk-arm64
 # X84_64: /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
-RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64; else export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64; fi \
+RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.17.0-openjdk-amd64; else export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64; fi \
     && export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar \
     && sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
     && sed -i "/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \


### PR DESCRIPTION
To automate docker setup on multiple types of architectures (especially RAM), I add codes in Dockerfile to first detect the architecture, then set JAVA_HOME accordingly.

CALL for TEST: To collect more user samples, if you are using MAC with M1&M2 chip, could you please help to test in your hardware?