### PR TITLE
Updating DockerfileMac to remedy Warnings

### DIFF
--- a/Docker/DockerfileMac
+++ b/Docker/DockerfileMac
@@ -24,14 +24,14 @@ RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-3.3.6/hadoop-3.3
 RUN wget https://repo1.maven.org/maven2/org/json/json/20240205/json-20240205.jar
 RUN mkdir json-lib
 RUN mv json-*.jar json-lib 
-ENV HADOOP_PREFIX /usr/local/hadoop
-ENV HADOOP_COMMON_HOME /usr/local/hadoop
-ENV HADOOP_HDFS_HOME /usr/local/hadoop
-ENV HADOOP_MAPRED_HOME /usr/local/hadoop
-ENV HADOOP_YARN_HOME /usr/local/hadoop
-ENV HADOOP_CONF_DIR /usr/local/hadoop/etc/hadoop
-ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
-ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar:/json-lib/*.jar
+ENV HADOOP_PREFIX=/usr/local/hadoop
+ENV HADOOP_COMMON_HOME=/usr/local/hadoop
+ENV HADOOP_HDFS_HOME=/usr/local/hadoop
+ENV HADOOP_MAPRED_HOME=/usr/local/hadoop
+ENV HADOOP_YARN_HOME=/usr/local/hadoop
+ENV HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop
+ENV YARN_CONF_DIR=$HADOOP_PREFIX/etc/hadoop
+#ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar:/json-lib/*.jar
 ENV PATH="/usr/local/hadoop/bin:${PATH}"
 
 # Test the arch and set JAVA_HOME accordingly:
@@ -39,7 +39,7 @@ ENV PATH="/usr/local/hadoop/bin:${PATH}"
 # X84_64: /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.21.0-openjdk-amd64; else export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-arm64; fi \
-    && export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar \
+    && export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar:/json-lib/*.jar \
     && sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
     && sed -i "/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
     && echo "export JAVA_HOME=$JAVA_HOME" >> $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \


### PR DESCRIPTION
When building the dockerfile for MacOS, we get several warnings:
```
9 warnings found (use docker --debug to expand):
 - UndefinedVar: Usage of undefined variable '$JAVA_HOME' (line 34)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 34)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 33)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 28)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 29)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 30)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 31)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 32)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 27)
```

The bulk was primarily from ENV's needing to be in `key=value` format.
`$JAVA_HOME` is undefined, so that ENV line is commented out and added to line 42:
```
&& export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar:/json-lib/*.jar \
```